### PR TITLE
Ignore .DS_store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Mac Junk
+.DS_Store


### PR DESCRIPTION
The OS X Finder App drops these files in any directory you visit with it.  Typically you should just add the file to your .gitignore.  I do this here for you.  👍 