### PR TITLE
Appended python extension to reference test file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -112,4 +112,4 @@ Tips
 
 To run a subset of tests::
 
-    py.test tests/test_planetary_test_data
+    py.test tests/test_planetary_test_data.py


### PR DESCRIPTION
Should be an obvious fix, corrects documentation.